### PR TITLE
fix (thread): некорректная работа World.stop()

### DIFF
--- a/ru/cyberbiology/World.java
+++ b/ru/cyberbiology/World.java
@@ -355,8 +355,16 @@ public class World implements IWorld {
     }
 
     public void stop() {
+        if (thread == null) {
+            return;
+        }
         started = false;
-        this.thread = null;
+        try {
+            thread.join();
+        } catch (InterruptedException ex) {
+            Logger.getLogger(World.class.getName()).log(Level.SEVERE, null, ex);
+        }
+        thread = null;
     }
 
     public boolean isRecording() {


### PR DESCRIPTION
    В методе stop() устанавливался флаг started = false, но, при этом не
    производилось ожидание остановки потока Worker. Это приводило к тому, что код
    после started = false выполнялся параллельно потоку Worker. В потоке
    Worker происходит проход по массиву matrix и пересчет мира.
    Соответственно, если код, выполняющийся посте установки флага
    started = false, обращается к matrix, то происходит одновременный
    доступ к этому массиву, что приводит к непредвиденным результатам. В
    частности, из-за этого, события "Сбой генома" и "Случайная мутация"
    приводили к остановке пересчета.

    Fixes #5